### PR TITLE
Add spm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Please check out the [demo][demo], the [API][api] and the [F.A.Q.][faq].
 Download: [HTML.min.js][full-min] or [HTML.js][full] [![Build Status](https://travis-ci.org/nbubna/HTML.png?branch=master)](https://travis-ci.org/nbubna/HTML)  
 [Bower][bower]: `bower install HTML`  
 [NPM][npm]: `npm install html.js`   
+[spm][spm]: `spm install html.js`   
 [Component][component]: `component install nbubna/HTML`  
 
 Includes [dot-traversal][dot], [`query()`][query], [`each()`][each], [`only()`][only], [`all()`][all], [`add()`][add], [`remove()`][remove], [`HTML.ify()`][ify] and [emmet abbreviations][abbr] in [`add()`][add-emmet]:  
@@ -21,6 +22,7 @@ Includes [dot-traversal][dot], [`query()`][query], [`each()`][each], [`only()`][
 * [HTML.emmet.js][emmet]
 
 [npm]: https://npmjs.org/package/html.js
+[spm]: http://spm.io/package/html.js
 [bower]: http://bower.io/
 [component]: http://component.io/
 

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "element",
     "emmet",
     "native"
-  ]
+  ],
+  "spm": {
+    "main": "dist/HTML.js"
+  }
 }


### PR DESCRIPTION
A nice package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/html.js

---

It is a browser-side package manager popular in China, suppling a complete lifecycle managment of package via [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of html.js in spmjs, I would like add it for your account after signing in http://spmjs.io.

spmjs/spm#781